### PR TITLE
handle a .well-known URI

### DIFF
--- a/speedtest/speedtest.go
+++ b/speedtest/speedtest.go
@@ -227,6 +227,11 @@ func SpeedTest(c *cli.Context) error {
 		log.Info("Retrieving server list from %s", serverUrl)
 
 		servers, err = getServerList(c.Bool(defs.OptionSecure), serverUrl, c.IntSlice(defs.OptionExclude), c.IntSlice(defs.OptionServer), !c.Bool(defs.OptionList))
+
+		if err != nil {
+			log.Info("Retry with /.well-known/librespeed")
+			servers, err = getServerList(c.Bool(defs.OptionSecure), serverUrl + "/.well-known/librespeed", c.IntSlice(defs.OptionExclude), c.IntSlice(defs.OptionServer), !c.Bool(defs.OptionList))
+		}
 	}
 	if err != nil {
 		log.Errorf("Error when fetching server list: %s", err)

--- a/speedtest/speedtest.go
+++ b/speedtest/speedtest.go
@@ -220,11 +220,11 @@ func SpeedTest(c *cli.Context) error {
 		servers, err = getLocalServers(c.Bool(defs.OptionSecure), str, c.IntSlice(defs.OptionExclude), c.IntSlice(defs.OptionServer), !c.Bool(defs.OptionList))
 	} else {
 		// fetch the server list JSON and parse it into the `servers` array
-		log.Info("Retrieving LibreSpeed.org server list")
 		serverUrl := serverListUrl
 		if str := c.String(defs.OptionServerJSON); str != "" {
 			serverUrl = str
 		}
+		log.Info("Retrieving server list from %s", serverUrl)
 
 		servers, err = getServerList(c.Bool(defs.OptionSecure), serverUrl, c.IntSlice(defs.OptionExclude), c.IntSlice(defs.OptionServer), !c.Bool(defs.OptionList))
 	}


### PR DESCRIPTION
retry remote fetch with .well-known URI

Instead of having to type a whole URI, expect the JSON server list to be served at /.well-known/librespeed

Thus, only the base URL should be necessary.