### PR TITLE
Decimal places at jitter and ping.

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ GLOBAL OPTIONS:
    --upload-size value            Size of payload being uploaded in KiB (default: 1024)
    --secure                       Use HTTPS instead of HTTP when communicating with
                                   LibreSpeed.org operated servers (default: false)
-   --skip-cert-verify             Skip verifying SSL certificate for HTTPS connections (self-signed certs) (default: false)								  
+   --skip-cert-verify             Skip verifying SSL certificate for HTTPS connections (self-signed certs) (default: false)
    --no-pre-allocate              Do not pre allocate upload data. Pre allocation is
                                   enabled by default to improve upload performance. To
                                   support systems with insufficient memory, use this

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ For Linux users, you can use either the archive from golang.org, or install from
     ```shell script
     # pacman -S go
     ```
-   
+
 2. Then, clone the repository:
 
     ```shell script
@@ -59,10 +59,10 @@ can now proceed to build `librespeed-cli` with the build script:
 
     If you want to build for another operating system or system architecture, use the `GOOS` and `GOARCH` environment
     variables. Run `go tool dist list` to get a list of possible combinations of `GOOS` and `GOARCH`.
-    
+
     Note: Technically, the CLI can be compiled with older Go versions that support Go modules, with `GO111MODULE=on`
     set. If you're compiling with an older Go runtime, you might have to change the Go version in `go.mod`.
-    
+
     ```shell script
     # Let's say we're building for 64-bit Windows on Linux
     $ GOOS=windows GOARCH=amd64 ./build.sh
@@ -74,7 +74,7 @@ can now proceed to build `librespeed-cli` with the build script:
     $ ls out
     librespeed-cli-windows-amd64.exe
     ```
-   
+
 5. Now you can use the `librespeed-cli` and test your Internet speed!
 
 ## Install from AUR
@@ -145,7 +145,7 @@ GLOBAL OPTIONS:
                                   multiple times. Cannot be used with --server
    --server-json value            Use an alternative server list from remote JSON file
    --local-json value             Use an alternative server list from local JSON file,
-                                  or read from stdin with "--local-json -".   
+                                  or read from stdin with "--local-json -".
    --source SOURCE                SOURCE IP address to bind to
    --timeout TIMEOUT              HTTP TIMEOUT in seconds. (default: 15)
    --duration value               Upload and download test duration in seconds (default: 15)
@@ -205,7 +205,7 @@ As you can see in the example, all servers have their schemes defined. In case o
 `librespeed-cli` will use `http` by default, or `https` when the `--secure` option is enabled.
 
 ## Use a custom telemetry server
-By default, the telemetry result will be sent to `librespeed.org`. You can also customize your telemetry settings 
+By default, the telemetry result will be sent to `librespeed.org`. You can also customize your telemetry settings
 via the `--telemetry` prefixed options. In order to load a custom telemetry endpoint configuration, you'll have to use the
 `--telemetry-json` option to specify a local JSON file containing the configuration bits. The format is as below:
 

--- a/speedtest/helper.go
+++ b/speedtest/helper.go
@@ -79,7 +79,7 @@ func doSpeedTest(c *cli.Context, servers []defs.Server, telemetryServer defs.Tel
 			}
 
 			if pb != nil {
-				pb.FinalMSG = fmt.Sprintf("Ping: %.0f ms\tJitter: %.0f ms\n", p, jitter)
+				pb.FinalMSG = fmt.Sprintf("Ping: %.2f ms\tJitter: %.2f ms\n", p, jitter)
 				pb.Stop()
 			}
 
@@ -117,9 +117,9 @@ func doSpeedTest(c *cli.Context, servers []defs.Server, telemetryServer defs.Tel
 			if c.Bool(defs.OptionSimple) {
 				if c.Bool(defs.OptionBytes) {
 					useMebi := c.Bool(defs.OptionMebiBytes)
-					log.Warnf("Ping:\t%.0f ms\tJitter:\t%.0f ms\nDownload rate:\t%s\nUpload rate:\t%s", p, jitter, humanizeMbps(downloadValue, useMebi), humanizeMbps(uploadValue, useMebi))
+					log.Warnf("Ping:\t%.2f ms\tJitter:\t%.2f ms\nDownload rate:\t%s\nUpload rate:\t%s", p, jitter, humanizeMbps(downloadValue, useMebi), humanizeMbps(uploadValue, useMebi))
 				} else {
-					log.Warnf("Ping:\t%.0f ms\tJitter:\t%.0f ms\nDownload rate:\t%.2f Mbps\nUpload rate:\t%.2f Mbps", p, jitter, downloadValue, uploadValue)
+					log.Warnf("Ping:\t%.2f ms\tJitter:\t%.2f ms\nDownload rate:\t%.2f Mbps\nUpload rate:\t%.2f Mbps", p, jitter, downloadValue, uploadValue)
 				}
 			}
 
@@ -149,7 +149,7 @@ func doSpeedTest(c *cli.Context, servers []defs.Server, telemetryServer defs.Tel
 
 				rep.Name = currentServer.Name
 				rep.Address = u.String()
-				rep.Ping = p
+				rep.Ping = math.Round(p*100) / 100
 				rep.Jitter = math.Round(jitter*100) / 100
 				rep.Download = math.Round(downloadValue*100) / 100
 				rep.Upload = math.Round(uploadValue*100) / 100
@@ -162,7 +162,7 @@ func doSpeedTest(c *cli.Context, servers []defs.Server, telemetryServer defs.Tel
 				var rep report.JSONReport
 				rep.Timestamp = time.Now()
 
-				rep.Ping = p
+				rep.Ping = math.Round(p*100) / 100
 				rep.Jitter = math.Round(jitter*100) / 100
 				rep.Download = math.Round(downloadValue*100) / 100
 				rep.Upload = math.Round(uploadValue*100) / 100
@@ -175,15 +175,15 @@ func doSpeedTest(c *cli.Context, servers []defs.Server, telemetryServer defs.Tel
 
 				rep.Client = report.Client{ispInfo.RawISPInfo}
 				rep.Client.Readme = ""
-				
-				reps_json = append(reps_json,rep)
+
+				reps_json = append(reps_json, rep)
 			}
 		} else {
 			log.Infof("Selected server %s (%s) is not responding at the moment, try again later", currentServer.Name, u.Hostname())
 		}
 
 		//add a new line after each test if testing multiple servers
-		if ( len(servers) > 1 &&  !silent){
+		if len(servers) > 1 && !silent {
 			log.Warn()
 		}
 	}
@@ -240,7 +240,7 @@ func sendTelemetry(telemetryServer defs.TelemetryServer, ispInfo *defs.GetIPResu
 	if fPing, err := wr.CreateFormField("ping"); err != nil {
 		log.Debugf("Error creating form field: %s", err)
 		return "", err
-	} else if _, err = fPing.Write([]byte(strconv.Itoa(int(pingVal)))); err != nil {
+	} else if _, err = fPing.Write([]byte(strconv.FormatFloat(pingVal, 'f', 2, 64))); err != nil {
 		log.Debugf("Error writing form field: %s", err)
 		return "", err
 	}
@@ -248,7 +248,7 @@ func sendTelemetry(telemetryServer defs.TelemetryServer, ispInfo *defs.GetIPResu
 	if fJitter, err := wr.CreateFormField("jitter"); err != nil {
 		log.Debugf("Error creating form field: %s", err)
 		return "", err
-	} else if _, err = fJitter.Write([]byte(strconv.Itoa(int(jitter)))); err != nil {
+	} else if _, err = fJitter.Write([]byte(strconv.FormatFloat(jitter, 'f', 2, 64))); err != nil {
 		log.Debugf("Error writing form field: %s", err)
 		return "", err
 	}

--- a/speedtest/speedtest.go
+++ b/speedtest/speedtest.go
@@ -64,6 +64,7 @@ func SpeedTest(c *cli.Context) error {
 
 	// print version
 	if c.Bool(defs.OptionVersion) {
+		log.SetOutput(os.Stdout)
 		log.Warnf("%s %s (built on %s)", defs.ProgName, defs.ProgVersion, defs.BuildDate)
 		log.Warn("https://github.com/librespeed/speedtest-cli")
 		log.Warn("Licensed under GNU Lesser General Public License v3.0")
@@ -80,7 +81,7 @@ func SpeedTest(c *cli.Context) error {
 	if c.Bool(defs.OptionCSVHeader) {
 		var rep []report.CSVReport
 		b, _ := gocsv.MarshalBytes(&rep)
-		log.Warnf("%s", b)
+		os.Stdout.WriteString(string(b))
 		return nil
 	}
 


### PR DESCRIPTION
Some small adjustments in one pull request.
- Changed output type to stdout for --version and --csv-header. Addition to "send --json and --csv results to stdout and logs to stderr https://github.com/librespeed/speedtest-cli/pull/39"
- decimal places at jitter and ping, better values with --share, this limits/extended ping and jitter to .2 decimal places at --csv / --json and stdout. Also it prevents 1.0909090909090908 ping times within csv and json and extend those values in rest of the data. (the initial reason for the change)
- formatting, tabs, spaces and blank lines 
 