### PR TITLE
Add Windows installation options to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![LibreSpeed Logo](https://github.com/librespeed/speedtest/blob/master/.logo/logo3.png?raw=true)
 
 # LibreSpeed command line tool
-Don't have a GUI but wants to use LibreSpeed servers to test your Internet speed? 🚀
+Don't have a GUI but want to use LibreSpeed servers to test your Internet speed? 🚀
 
 `librespeed-cli` comes to rescue!
 
@@ -96,6 +96,20 @@ $ makepkg -si
 ## Install from Homebrew
 
 See the [librespeed-cli Homebrew tap](https://github.com/librespeed/homebrew-tap#setup).
+
+## Install on Windows
+
+If you have either [Scoop](https://scoop.sh/) or [Chocolatey](https://chocolatey.org/) installed you can use one of the following commands:
+
+- Scoop (ensure you have the `extras` bucket added):
+  ```
+  > scoop install librespeed-cli
+  ```
+
+- Chocolatey:
+  ```
+  > choco install librespeed-cli
+  ```
 
 ## Container Image
 


### PR DESCRIPTION
LibreSpeed CLI was [recently added to the Scoop package repositories](https://github.com/ScoopInstaller/Extras/pull/8866) so this is a PR adding some Windows installation options to the Readme. It lists the commands for installing with Scoop or Chocolatey. It also fixes a typo in the first line of text.