### PR TITLE
throw an error if the specified `--server` is not in server list

### DIFF
--- a/speedtest/speedtest.go
+++ b/speedtest/speedtest.go
@@ -454,6 +454,10 @@ func preprocessServers(servers []defs.Server, forceHTTPS bool, excludes, specifi
 					ret = append(ret, server)
 				}
 			}
+			if len(ret) == 0 {
+				error_message := fmt.Sprintf("specified server(s) not found: %v", specific)
+				return nil, errors.New(error_message)
+			}
 			return ret, nil
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/librespeed/speedtest-cli/issues/55

---

Testing
```bash
cat <<EOF > /tmp/server-list.json
[
  {
    "pingURL": "empty.php", 
    "name": "Amsterdam, Netherlands (Clouvider)", 
    "sponsorURL": "https://www.clouvider.co.uk/", 
    "getIpURL": "getIP.php", 
    "ulURL": "empty.php", 
    "sponsorName": "Clouvider", 
    "id": 51, 
    "dlURL": "garbage.php", 
    "server": "//ams.speedtest.clouvider.net/backend"
  }
]
EOF
```
<img width="816" alt="Screenshot 2022-07-22 at 22 43 34" src="https://user-images.githubusercontent.com/2742870/180566829-991d2891-e674-4a99-8d34-813c067475da.png">


