### PR TITLE
make `--version` to report the binary version again

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -10,9 +10,10 @@ CURRENT_DIR=$(pwd)
 OUT_DIR=${CURRENT_DIR}/out
 
 PROGNAME="librespeed-cli"
+DEFS_PATH="github.com/librespeed/speedtest-cli"
 BINARY=${PROGNAME}-$(go env GOOS)-$(go env GOARCH)
 BUILD_DATE=$(date -u "+%Y-%m-%d %H:%M:%S %Z")
-LDFLAGS="-w -s -X \"librespeed-cli/defs.ProgName=${PROGNAME}\" -X \"librespeed-cli/defs.ProgVersion=${PROGVER}\" -X \"librespeed-cli/defs.BuildDate=${BUILD_DATE}\""
+LDFLAGS="-w -s -X \"${DEFS_PATH}/defs.ProgName=${PROGNAME}\" -X \"${DEFS_PATH}/defs.ProgVersion=${PROGVER}\" -X \"${DEFS_PATH}/defs.BuildDate=${BUILD_DATE}\""
 
 if [[ -n "${GOARM}" ]] && [[ "${GOARM}" -gt 0 ]]; then
   BINARY=${BINARY}v${GOARM}


### PR DESCRIPTION
Fixes https://github.com/librespeed/speedtest-cli/issues/57

<img width="737" alt="Screenshot 2022-08-10 at 14 11 12" src="https://user-images.githubusercontent.com/2742870/183897758-9e26ad73-72f8-485b-ade9-91305f2713b8.png">
