### PR TITLE
Reduced container image size

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,4 +1,6 @@
-FROM golang:1.17.7-buster as builder
+FROM golang:1.20.3-alpine as builder
+
+RUN apk add --no-cache bash 
 
 # Set working directory
 WORKDIR /usr/src/librespeed-cli
@@ -9,9 +11,9 @@ COPY . .
 # Build librespeed-cli
 RUN ./build.sh
 
-FROM golang:1.17.7-buster
+FROM alpine:3.17
 
 # Copy librespeed-cli binary
-COPY --from=builder /usr/src/librespeed-cli/out/librespeed-cli* /usr/src/librespeed-cli/librespeed-cli
+COPY --from=builder /usr/src/librespeed-cli/out/librespeed-cli* /bin/librespeed-cli
 
-ENTRYPOINT ["/usr/src/librespeed-cli/librespeed-cli"]
+CMD ["/bin/librespeed-cli"]


### PR DESCRIPTION
We don't need Golang images to run the pre-built binary so I switched it to Alpine which is a lot smaller.

I had to switch to an Alpine builder image as well since it would be incompatible otherwise and bumped the golang environment version there to 1.20.3.

I'd say the reduction in size is well worth it.

Results:
```
speedtest-cli ❯ docker images 
REPOSITORY                    TAG               IMAGE ID       CREATED          SIZE
czechbol/new-librespeed       latest            12806146233a   15 seconds ago   14.3MB
czechbol/orig-librespeed      latest            74fa60a3e391   2 minutes ago    890MB

speedtest-cli ❯ docker run -it --rm czechbol/new-librespeed:latest 
Retrieving server list from https://librespeed.org/backend-servers/servers.php
Selecting the fastest server based on ping
Selected server: Virginia, United States, OVH [speed.riverside.rocks]
Sponsored by: Riverside Rocks @ https://riverside.rocks
You're testing from: {"processedString":"<redacted> - Unknown ISP","rawIspInfo":""}
Ping: 12.00 ms  Jitter: 3.66 ms
Download rate:  75.53 Mbps
Upload rate:    68.28 Mbps
```