### PR TITLE
Fix code-highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ You can run `librespeed-cli` in a container.
 
 You can see the full list of supported options with `librespeed-cli -h`:
 
-```shell script
+```
 $ librespeed-cli -h
 NAME:
    librespeed-cli - Test your Internet speed with LibreSpeed 🚀


### PR DESCRIPTION
CLI help output is wrongly interpreted as shell script, thus disable code highlighting for this block.