### PR TITLE
add `--ca-cert` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,8 @@ GLOBAL OPTIONS:
    --upload-size value            Size of payload being uploaded in KiB (default: 1024)
    --secure                       Use HTTPS instead of HTTP when communicating with
                                   LibreSpeed.org operated servers (default: false)
+   --ca-cert value                Use the specified CA certificate PEM bundle file instead
+                                  of the system certificate trust store
    --skip-cert-verify             Skip verifying SSL certificate for HTTPS connections (self-signed certs) (default: false)
    --no-pre-allocate              Do not pre allocate upload data. Pre allocation is
                                   enabled by default to improve upload performance. To

--- a/defs/options.go
+++ b/defs/options.go
@@ -29,6 +29,7 @@ const (
 	OptionUploadSize      = "upload-size"
 	OptionDuration        = "duration"
 	OptionSecure          = "secure"
+	OptionCACert          = "ca-cert"
 	OptionSkipCertVerify  = "skip-cert-verify"
 	OptionNoPreAllocate   = "no-pre-allocate"
 	OptionVersion         = "version"

--- a/main.go
+++ b/main.go
@@ -164,6 +164,11 @@ func main() {
 				Usage: "Use HTTPS instead of HTTP when communicating with\n" +
 					"\tLibreSpeed.org operated servers",
 			},
+			&cli.StringFlag{
+				Name: defs.OptionCACert,
+				Usage: "Use the specified CA certificate PEM bundle file instead\n" +
+				    "\tof the system certificate trust store",
+			},
 			&cli.BoolFlag{
 				Name:  defs.OptionSkipCertVerify,
 				Usage: "Skip verifying SSL certificate for HTTPS connections (self-signed certs)",


### PR DESCRIPTION
Adds the `--ca-cert` option to specify the file name of the CA certificate PEM bundle to use for verifying certificates. 

The default behavior (ie without this option) is to use the system certificate trust store which is `/etc/ssl/certs` on Linux systems. This option overrides that by specifying a specific PEM bundle file.  

Fixes https://github.com/librespeed/speedtest-cli/issues/80