### PR TITLE
fix start serverIdx in pingList when some servers are down

### DIFF
--- a/speedtest/speedtest.go
+++ b/speedtest/speedtest.go
@@ -317,6 +317,10 @@ func SpeedTest(c *cli.Context) error {
 
 		// get the fastest server's index in the `servers` array
 		var serverIdx int
+		for serverIdx = range pingList {
+			break
+		}
+
 		for idx, ping := range pingList {
 			if ping > 0 && ping <= pingList[serverIdx] {
 				serverIdx = idx


### PR DESCRIPTION
Fix bug: as below json example, when first server in config file is down/not exist/error, the selected idx will be 0, the correct index should be 1.

json example:

```json
[
  {
    "id": 2,
    "name": "noexist",
    "server": "http://not.exist:8989",
     "dlURL": "garbage.php",
    "ulURL": "empty.php",
    "pingURL": "empty.php",
    "getIpURL": "getIP.php"
  },
  {
    "id": 3,
    "name": "good",
    "server": "http://good.server:8989",
     "dlURL": "garbage.php",
    "ulURL": "empty.php",
    "pingURL": "empty.php",
    "getIpURL": "getIP.php"
  }
]
```