### PR TITLE
fix docker build and run

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,6 +1,6 @@
-FROM golang:1.20.3-alpine as builder
+FROM golang:1.23.0-alpine AS builder
 
-RUN apk add --no-cache bash upx
+RUN apk add --no-cache bash upx git
 
 # Set working directory
 WORKDIR /usr/src/librespeed-cli
@@ -16,4 +16,4 @@ FROM alpine:3.17
 # Copy librespeed-cli binary
 COPY --from=builder /usr/src/librespeed-cli/out/librespeed-cli* /bin/librespeed-cli
 
-CMD ["/bin/librespeed-cli"]
+ENTRYPOINT ["/bin/librespeed-cli"]


### PR DESCRIPTION
build error:
```
./build.sh: line 4: git: command not found
go: errors parsing go.mod:
/usr/src/librespeed-cli/go.mod:3: invalid go version '1.23.0': must match format 1.23
/usr/src/librespeed-cli/go.mod:5: unknown directive: toolchain 
```
and can not run with options.