### PR TITLE
fix: fix server selection based on ping results

### DIFF
--- a/defs/server.go
+++ b/defs/server.go
@@ -59,9 +59,10 @@ func (s *Server) IsUp() bool {
 		return false
 	}
 	defer resp.Body.Close()
-	b, _ := ioutil.ReadAll(resp.Body)
-	if len(b) > 0 {
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil || len(b) > 0 {
 		log.Debugf("Failed when parsing get IP result: %s", b)
+		return false
 	}
 	// only return online if the ping URL returns nothing and 200
 	return resp.StatusCode == http.StatusOK

--- a/speedtest/helper.go
+++ b/speedtest/helper.go
@@ -18,7 +18,7 @@ import (
 	"github.com/librespeed/speedtest-cli/defs"
 	"github.com/librespeed/speedtest-cli/report"
 	log "github.com/sirupsen/logrus"
-"github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v2"
 )
 
 const (

--- a/speedtest/speedtest.go
+++ b/speedtest/speedtest.go
@@ -321,8 +321,14 @@ func SpeedTest(c *cli.Context) error {
 
 		// get the fastest server's index in the `servers` array
 		var serverIdx int
-		for idx, ping := range pingList {
-			if ping > 0 && ping <= pingList[serverIdx] {
+		for idx, newPing := range pingList {
+			oldPing, ok := pingList[serverIdx]
+
+			if ok {
+				if newPing > 0 && newPing <= oldPing {
+					serverIdx = idx
+				}
+			} else {
 				serverIdx = idx
 			}
 		}


### PR DESCRIPTION
Fixes https://github.com/librespeed/speedtest-cli/issues/51 

Related PR:
- https://github.com/librespeed/speedtest-cli/pull/94

#### Testing
The binary with the `--old` suffix `v1.0.12` binary and the one with the `--new` tag is a binary built with this PR's changes. 
<img width="935" height="413" alt="Screenshot 2025-11-14 at 16 46 14" src="https://github.com/user-attachments/assets/1467b93b-ad09-4dfb-bc54-c9bf1cebcca6" />

