### PR TITLE
docs: describe what --secure and --insecure actually do

### DIFF
--- a/main.go
+++ b/main.go
@@ -150,13 +150,16 @@ func main() {
 			},
 			&cli.BoolFlag{
 				Name: defs.OptionSecure,
-				Usage: "Use HTTPS instead of HTTP when communicating with\n" +
-					"\tLibreSpeed.org operated servers",
+				Usage: "Force HTTPS for every test server, whichever scheme the\n" +
+					"\tserver list gives. Does not affect how the server list\n" +
+					"\titself is fetched",
 			},
 			&cli.BoolFlag{
 				Name: defs.OptionInsecure,
-				Usage: "Use HTTP instead of HTTPS when communicating with\n" +
-					"\tLibreSpeed.org operated servers",
+				Usage: "Force HTTP for every test server, whichever scheme the\n" +
+					"\tserver list gives. Does not affect how the server list\n" +
+					"\titself is fetched; use --" + defs.OptionServerJSON + " with an\n" +
+					"\thttp:// URL for that",
 			},
 			&cli.StringFlag{
 				Name: defs.OptionCACert,


### PR DESCRIPTION
Both said they applied "when communicating with LibreSpeed.org operated
servers". Wrong twice: they apply to every server in the list, including
`--local-json` and `--server-json` ones, and they don't affect fetching the
list itself.

```
$ librespeed-cli --insecure --list
Retrieving server list from https://librespeed.org/backend-servers/servers.php
51: Amsterdam, Netherlands (Clouvider) (http://ams.speedtest.clouvider.net/backend)
```

Help text only.