### PR TITLE
fix: terminate output with a newline, drop the empty copyright line

### DIFF
--- a/speedtest/helper.go
+++ b/speedtest/helper.go
@@ -197,13 +197,14 @@ func doSpeedTest(c *cli.Context, servers []defs.Server, telemetryServer defs.Tel
 		if err := gocsv.MarshalWithoutHeaders(&reps_csv, &buf); err != nil {
 			output.WriteError("Error generating CSV report: %s\n", err)
 		} else {
-			os.Stdout.WriteString(strings.TrimRight(buf.String(), "\n\r"))
+			os.Stdout.WriteString(strings.TrimRight(buf.String(), "\n\r") + "\n")
 		}
 	} else if c.Bool(defs.OptionJSON) {
 		if b, err := json.Marshal(&reps_json); err != nil {
 			output.WriteError("Error generating JSON report: %s\n", err)
 		} else {
 			os.Stdout.Write(b[:])
+			os.Stdout.WriteString("\n")
 		}
 	}
 

--- a/speedtest/speedtest.go
+++ b/speedtest/speedtest.go
@@ -73,7 +73,6 @@ func SpeedTest(c *cli.Context) error {
 		output.WriteOut("Licensed under GNU Lesser General Public License v3.0\n")
 		output.WriteOut("LibreSpeed\tCopyright (C) 2016-2020 Federico Dossena\n")
 		output.WriteOut("librespeed-cli\tCopyright (C) 2020 Maddie Zhan\n")
-		output.WriteOut("librespeed.org\tCopyright (C)\n")
 		return nil
 	}
 


### PR DESCRIPTION
Two output nits, one commit each.

`--json` and `--csv` end without a trailing newline — `--json` writes the
marshalled bytes as-is, `--csv` explicitly trims it. The shell prompt lands
on the same line as the result, and appending one `--csv` run to another
glues the last field of the first into the first field of the second:

```
$ { librespeed-cli --csv; librespeed-cli --csv; } | python3 -c "import csv,sys; print([len(r) for r in csv.reader(sys.stdin)])"
[17]     # one 17-column row instead of two 9-column rows
```

And `--version` prints `librespeed.org	Copyright (C)` — no holder, no year,
unchanged since the first commit.

After: exactly one `\n` on both. `jq` already accepted the JSON; the change
just makes the output line-oriented like every other CLI.