### PR TITLE
feat: report the negotiated TLS version and cipher under --debug

### DIFF
--- a/defs/server.go
+++ b/defs/server.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -59,6 +60,21 @@ func (s *Server) IsUp() bool {
 		return false
 	}
 	defer resp.Body.Close()
+
+	// Report what the connection actually negotiated. On hardware without AES
+	// acceleration the cipher, not the link, is what bounds the result, and
+	// under TLS 1.3 the server picks it: the client offers a set and has no say
+	// in the choice, and Go does not allow that set to be configured at all.
+	// Two runs can therefore differ several-fold for a reason the numbers alone
+	// do not show, which is what this line is for.
+	if resp.TLS != nil {
+		output.WriteDebug("Negotiated %s with %s\n",
+			tls.VersionName(resp.TLS.Version),
+			tls.CipherSuiteName(resp.TLS.CipherSuite))
+	} else {
+		output.WriteDebug("Connection is not encrypted\n")
+	}
+
 	b, err := io.ReadAll(resp.Body)
 	if err != nil || len(b) > 0 {
 		output.WriteDebug("Failed when parsing get IP result: %s\n", b)


### PR DESCRIPTION
On hardware without AES acceleration the cipher, not the link, bounds an
HTTPS result — and under TLS 1.3 the server picks it. The client offers a
set and has no say in the choice, and Go does not allow that set to be
configured at all (`CipherSuites` covers TLS 1.0–1.2 only). Two runs can
then differ several-fold for a reason the numbers do not show.

Measured on a CZ.NIC Turris 1.x, whose e500v2 core has no crypto
instructions:

| | throughput |
|---|---|
| AES-256-GCM | ~150 Mbps |
| ChaCha20-Poly1305 | ~390 Mbps |

Same core, same link. A server that picks the first looks like a slow link
next to one that picks the second, and nothing in the report says which
happened.

```
$ librespeed-cli --server 85 --debug
Negotiated TLS 1.3 with TLS_AES_256_GCM_SHA384

$ librespeed-cli --server 85 --insecure --debug
Connection is not encrypted
```

Printed once, from the backend check that already runs before every test.
Nothing changes without `--debug`, and the JSON and CSV schemas are
untouched.