### PR TITLE
feat: report which address each ping test used under --debug

### DIFF
--- a/defs/address_test.go
+++ b/defs/address_test.go
@@ -1,0 +1,33 @@
+package defs
+
+import "testing"
+
+func TestAddressFamily(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"bare IPv4", "198.51.100.7", "IPv4"},
+		{"IPv4 with port", "198.51.100.7:8080", "IPv4"},
+		{"bare IPv6", "2001:db8::1", "IPv6"},
+		// A bare IPv6 address has more colons than a host:port split allows, so
+		// this is the case that breaks if the split result is trusted blindly.
+		{"IPv6 with port", "[2001:db8::1]:8080", "IPv6"},
+		{"IPv6 loopback", "::1", "IPv6"},
+		{"IPv4 loopback", "127.0.0.1", "IPv4"},
+		// Reported by the family actually carried, not by the notation.
+		{"IPv4-mapped IPv6", "::ffff:198.51.100.7", "IPv4"},
+		{"a hostname is not an address", "example.com", "unknown"},
+		{"empty", "", "unknown"},
+		{"nonsense", "not an address", "unknown"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := addressFamily(c.in); got != c.want {
+				t.Errorf("addressFamily(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}

--- a/defs/server.go
+++ b/defs/server.go
@@ -9,9 +9,12 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"net"
 	"net/http"
+	"net/http/httptrace"
 	"net/url"
 	"path"
+	"slices"
 	"strconv"
 	"time"
 
@@ -109,6 +112,15 @@ func (s *Server) ICMPPingAndJitter(count int, srcIp, network string) (float64, f
 
 	stats := p.Statistics()
 
+	// Say which address the test actually reached. IPv4 and IPv6 can take
+	// different paths through the network, so a result is not fully described
+	// by the hostname it was measured against, and --json carries no client
+	// address to infer it from.
+	if stats.IPAddr != nil {
+		output.WriteDebug("Pinging %s over ICMP (%s)\n",
+			stats.IPAddr.String(), addressFamily(stats.IPAddr.String()))
+	}
+
 	var lastPing, jitter float64
 	for idx, rtt := range stats.Rtts {
 		if idx != 0 {
@@ -131,6 +143,24 @@ func (s *Server) ICMPPingAndJitter(count int, srcIp, network string) (float64, f
 	}
 
 	return float64(stats.AvgRtt.Milliseconds()), jitter, nil
+}
+
+// addressFamily names the IP version of an address, for reporting which path a
+// measurement took. Accepts either a bare address or one with a port.
+func addressFamily(addr string) string {
+	host := addr
+	if h, _, err := net.SplitHostPort(addr); err == nil {
+		host = h
+	}
+	ip := net.ParseIP(host)
+	switch {
+	case ip == nil:
+		return "unknown"
+	case ip.To4() != nil:
+		return "IPv4"
+	default:
+		return "IPv6"
+	}
 }
 
 // PingAndJitter pings the server via accessing ping URL and calculate the average ping and jitter
@@ -156,6 +186,23 @@ func (s *Server) PingAndJitter(count int) (float64, float64, error) {
 	}
 	req.Header.Set("User-Agent", UserAgent)
 
+	// Collect every distinct peer, not just the first. The requests usually
+	// share one connection, but a reconnect can land on a different address --
+	// a different family, even -- and reporting only the first would then
+	// describe a connection the later samples did not use.
+	var remotes []string
+	req = req.WithContext(httptrace.WithClientTrace(req.Context(), &httptrace.ClientTrace{
+		GotConn: func(info httptrace.GotConnInfo) {
+			if info.Conn == nil {
+				return
+			}
+			addr := info.Conn.RemoteAddr().String()
+			if !slices.Contains(remotes, addr) {
+				remotes = append(remotes, addr)
+			}
+		},
+	}))
+
 	for i := 0; i < count; i++ {
 		start := time.Now()
 		resp, err := http.DefaultClient.Do(req)
@@ -168,6 +215,10 @@ func (s *Server) PingAndJitter(count int) (float64, float64, error) {
 		end := time.Now()
 
 		pings = append(pings, float64(end.Sub(start).Milliseconds()))
+	}
+
+	for _, addr := range remotes {
+		output.WriteDebug("Pinging %s over TCP (%s)\n", addr, addressFamily(addr))
 	}
 
 	// discard first result due to handshake overhead


### PR DESCRIPTION
IPv4 and IPv6 can take different paths through the network, so a result is
not fully described by the hostname it was measured against. Nothing in the
output says which was used — `--json` carries no client address, and the
human-readable line only shows it by accident, inside the ISP string.

It is not academic. Against `speedtest.cesnet.cz`, in the same run:

```
Pinging 78.128.211.42 over ICMP (IPv4)
Pinging [2001:718:1:1f:50:56ff:feee:42]:443 over TCP (IPv6)
```

The ICMP ping resolves separately from the HTTP client, so the reported
latency and the reported throughput can describe two different paths.

The ICMP path reports the address the pinger resolved and probed; the TCP
path reports the peer the socket actually connected to, taken from
`httptrace`. Both are covered because `--no-icmp` is common enough that
doing only the ICMP one would leave most users with nothing.