### PR TITLE
fix: keep sub-millisecond precision in ping and jitter

### DIFF
--- a/defs/rtt_test.go
+++ b/defs/rtt_test.go
@@ -1,0 +1,45 @@
+package defs
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRttMillis(t *testing.T) {
+	cases := []struct {
+		name string
+		in   time.Duration
+		want float64
+	}{
+		{"zero", 0, 0},
+		{"whole millisecond", time.Millisecond, 1},
+		{"a second", time.Second, 1000},
+		// Duration.Milliseconds truncates, so each of these would come back a
+		// whole millisecond short -- and the first three as no time at all.
+		{"a quarter of a millisecond", 250 * time.Microsecond, 0.25},
+		{"just under a millisecond", 999 * time.Microsecond, 0.999},
+		{"a single microsecond", time.Microsecond, 0.001},
+		{"one and a half milliseconds", 1500 * time.Microsecond, 1.5},
+		{"microsecond resolution is kept", 1234 * time.Microsecond, 1.234},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := rttMillis(c.in); got != c.want {
+				t.Errorf("rttMillis(%v) = %v, want %v", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+// A local link can answer well inside a millisecond, which is the case the
+// truncating conversion reported as zero.
+func TestRttMillisKeepsSubMillisecondApart(t *testing.T) {
+	fast, slow := rttMillis(200*time.Microsecond), rttMillis(800*time.Microsecond)
+	if fast >= slow {
+		t.Errorf("200us reported as %v, 800us as %v; the two should differ", fast, slow)
+	}
+	if fast == 0 {
+		t.Error("200us reported as 0 ms, which is what the truncating conversion did")
+	}
+}

--- a/defs/server.go
+++ b/defs/server.go
@@ -68,6 +68,13 @@ func (s *Server) IsUp() bool {
 	return resp.StatusCode == http.StatusOK
 }
 
+// rttMillis converts a round-trip time to milliseconds without discarding the
+// fraction. Duration.Milliseconds truncates to whole milliseconds, which on a
+// link faster than that leaves nothing to report.
+func rttMillis(d time.Duration) float64 {
+	return float64(d) / float64(time.Millisecond)
+}
+
 // ICMPPingAndJitter pings the server via ICMP echos and calculate the average ping and jitter
 func (s *Server) ICMPPingAndJitter(count int, srcIp, network string) (float64, float64, error) {
 	t := time.Now()
@@ -112,7 +119,7 @@ func (s *Server) ICMPPingAndJitter(count int, srcIp, network string) (float64, f
 	var lastPing, jitter float64
 	for idx, rtt := range stats.Rtts {
 		if idx != 0 {
-			instJitter := math.Abs(lastPing - float64(rtt.Milliseconds()))
+			instJitter := math.Abs(lastPing - rttMillis(rtt))
 			if idx > 1 {
 				if jitter > instJitter {
 					jitter = jitter*0.7 + instJitter*0.3
@@ -121,7 +128,7 @@ func (s *Server) ICMPPingAndJitter(count int, srcIp, network string) (float64, f
 				}
 			}
 		}
-		lastPing = float64(rtt.Milliseconds())
+		lastPing = rttMillis(rtt)
 	}
 
 	if len(stats.Rtts) == 0 {
@@ -130,7 +137,7 @@ func (s *Server) ICMPPingAndJitter(count int, srcIp, network string) (float64, f
 		return s.PingAndJitter(count + 2)
 	}
 
-	return float64(stats.AvgRtt.Milliseconds()), jitter, nil
+	return rttMillis(stats.AvgRtt), jitter, nil
 }
 
 // PingAndJitter pings the server via accessing ping URL and calculate the average ping and jitter
@@ -167,7 +174,7 @@ func (s *Server) PingAndJitter(count int) (float64, float64, error) {
 		resp.Body.Close()
 		end := time.Now()
 
-		pings = append(pings, float64(end.Sub(start).Milliseconds()))
+		pings = append(pings, rttMillis(end.Sub(start)))
 	}
 
 	// discard first result due to handshake overhead


### PR DESCRIPTION
`Duration.Milliseconds` truncates to whole milliseconds, and every round-trip
sample went through it — in the ICMP path and in the TCP fallback that
`--no-icmp` selects. On a link faster than a millisecond that leaves nothing.

Against a server on loopback, reporting only ping and jitter:

| | ping | jitter |
|---|---|---|
| before | **0** | **0** |
| after | 0.11 | 0.01 |

Over a wider link the reported ping still looks fractional, because it is an
average of the samples — but its resolution is a whole millisecond, and jitter
is a difference of those samples. Three consecutive ICMP runs against the same
server:

| | ping | jitter |
|---|---|---|
| before | 5, 6, 5 | 0.59, 4.40, 0.02 |
| after | 5.48, 5.68, 5.45 | 0.27, 0.32, 0.12 |

Dividing by `time.Millisecond` keeps the fraction.
