### PR TITLE
feat: report the ping distribution under --debug

### DIFF
--- a/defs/server.go
+++ b/defs/server.go
@@ -147,6 +147,18 @@ func (s *Server) ICMPPingAndJitter(count int, srcIp, network string) (float64, f
 		output.WriteDebug("Pinging %s over ICMP (%s)\n",
 			stats.IPAddr.String(), addressFamily(stats.IPAddr.String()))
 	}
+	// A single figure hides how the samples were spread. The pinger already
+	// works these out, and the spread is what says whether a link is steady or
+	// merely fast on average. Raw counts rather than a loss percentage: ten
+	// probes are too few for a rate, and ICMP is often policed independently of
+	// the data path, so a percentage would say more about the server's ICMP
+	// handling than about the network.
+	output.WriteDebug("Ping over ICMP: min %.2f ms, avg %.2f ms, max %.2f ms, stddev %.2f ms, %d/%d replies\n",
+		float64(stats.MinRtt.Microseconds())/1000,
+		float64(stats.AvgRtt.Microseconds())/1000,
+		float64(stats.MaxRtt.Microseconds())/1000,
+		float64(stats.StdDevRtt.Microseconds())/1000,
+		stats.PacketsRecv, stats.PacketsSent)
 
 	var lastPing, jitter float64
 	for idx, rtt := range stats.Rtts {


### PR DESCRIPTION
`--debug` reports a single average ping. That says nothing about how the
samples were spread, and the spread is usually what someone running with
`--debug` is trying to see: a link averaging 5 ms because every probe took
5 ms and one averaging 5 ms because probes ranged from 1 to 30 ms are not the
same link.

pro-bing already computes min, max and standard deviation in `Statistics()`,
so this prints what is on hand:

```
Ping over ICMP: min 5.71 ms, avg 5.89 ms, max 6.32 ms, stddev 0.18 ms, 10/10 replies
```

Replies are a raw count rather than a loss percentage. Ten probes are too few
to express as a rate, and ICMP is frequently policed separately from the data
path, so a percentage would describe the server's ICMP handling more than the
network.

ICMP only — `PingAndJitter()` measures over HTTP and has no equivalent figures
to report.