### PR TITLE
feat: name the platform in the User-Agent

### DIFF
--- a/defs/defs.go
+++ b/defs/defs.go
@@ -1,11 +1,19 @@
 package defs
 
+import "runtime"
+
 var (
 	// values to be filled in by build script
 	BuildDate   string
 	ProgName    string
 	ProgVersion string
-	UserAgent   = ProgName + "/" + ProgVersion
+	// UserAgent names the platform as well as the program, the way a browser
+	// does. A server's telemetry already stores this header, so reporting the
+	// operating system and architecture here is what lets an operator tell
+	// which kinds of machine are measuring against them without any change to
+	// what the client sends. It stays coarse deliberately: the kernel version
+	// or the hostname would identify the machine rather than describe it.
+	UserAgent = ProgName + "/" + ProgVersion + " (" + runtime.GOOS + "; " + runtime.GOARCH + ")"
 )
 
 // GetIPResults represents the returned JSON from backend server's getIP.php endpoint


### PR DESCRIPTION
A server's telemetry stores the `User-Agent` header already, but the client
identifies itself only by name and version, so an operator cannot tell what kind
of machine is measuring against them. Browsers have always reported this.

`runtime.GOOS` and `runtime.GOARCH` are compile-time constants, so this costs
nothing:

```
librespeed-cli/1.0.12 (linux; arm64)
```

Verified on the wire against a local server that logs the header, and
cross-built for `linux/arm64`, `linux/mips` and `linux/ppc64le`.

It stays coarse on purpose — the kernel version or the hostname would identify
the machine rather than describe it.