### PR TITLE
Add CI build checks and Dependabot, fix Docker build for Go 1.25

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,44 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  go:
+    name: Go build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+
+      - name: Build
+        run: ./build.sh ci
+
+      - name: Smoke test
+        run: ./out/librespeed-cli-linux-amd64 --version
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Test
+        run: go test ./...
+
+  docker:
+    name: Docker build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Build image
+        run: docker build -t librespeed-cli .
+
+      - name: Smoke test image
+        run: docker run --rm librespeed-cli --version

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.0-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 RUN apk add --no-cache bash upx git
 


### PR DESCRIPTION
## What

- Fix the Docker build for Go 1.25.
- Add CI checks for `go build`, `go vet`, `go test` and `docker build`, with a `--version` smoke run of the binary and the Docker image.
- Add weekly Dependabot updates for Go, Docker and GitHub Actions.

## Why

The Go version in go.mod and the Dockerfile got out of sync again after #134. The same issue already caused v1.0.13 and downstream builds to fail.

The CI check should catch this before the next release.

## Tested

`go build`, `go vet`, `go test` and `docker build .` all pass with these changes; the built binary and the image run `--version` successfully.
