### PR TITLE
fix: say which error terminated the run

### DIFF
--- a/main.go
+++ b/main.go
@@ -222,6 +222,6 @@ func main() {
 	// run main function with cli options
 	err := app.Run(os.Args)
 	if err != nil {
-		output.Fatal("Terminated due to error")
+		output.Fatalf("Terminated due to error: %s", err)
 	}
 }


### PR DESCRIPTION
Errors returned by the action ended in a bare message with the actual
error dropped:

    $ librespeed-cli --source 1.2.3.4 --interface eth0
    Terminated due to error

Now:

    Terminated due to error: incompatible options 'source' and 'interface'