### PR TITLE
feat: add --json-stream for machine-readable progress

### DIFF
--- a/defs/options.go
+++ b/defs/options.go
@@ -19,6 +19,7 @@ const (
 	OptionCSVDelimiter    = "csv-delimiter"
 	OptionCSVHeader       = "csv-header"
 	OptionJSON            = "json"
+	OptionJSONStream      = "json-stream"
 	OptionList            = "list"
 	OptionServer          = "server"
 	OptionExclude         = "exclude"

--- a/defs/server.go
+++ b/defs/server.go
@@ -284,6 +284,46 @@ func (s *Server) PingAndJitter(count int) (float64, float64, error) {
 }
 
 // Download performs the actual download test
+// streamProgress emits one progress event a second while a transfer phase
+// runs, reading the rate off the phase's byte counter. The returned stop
+// function ends the ticker and does not return until the goroutine is done,
+// so a late progress event can never land after the next phase event.
+func streamProgress(phase string, counter *BytesCounter, duration time.Duration) func() {
+	if !output.StreamEnabled() {
+		return func() {}
+	}
+
+	done := make(chan struct{})
+	stopped := make(chan struct{})
+	start := time.Now()
+
+	go func() {
+		defer close(stopped)
+		ticker := time.NewTicker(time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				elapsed := time.Since(start).Seconds()
+				output.WriteEvent(output.ProgressEvent{
+					Event:    "progress",
+					Phase:    phase,
+					Seconds:  math.Round(elapsed*10) / 10,
+					Mbps:     math.Round(counter.AvgMbps()*100) / 100,
+					Progress: int(math.Min(elapsed/duration.Seconds()*100, 100)),
+				})
+			}
+		}
+	}()
+
+	return func() {
+		close(done)
+		<-stopped
+	}
+}
+
 func (s *Server) Download(silent bool, useBytes, useMebi bool, requests int, chunks int, duration time.Duration) (float64, uint64, error) {
 	t := time.Now()
 	defer func() {
@@ -351,6 +391,7 @@ func (s *Server) Download(silent bool, useBytes, useMebi bool, requests int, chu
 	}
 
 	counter.Start()
+	defer streamProgress("download", counter, duration)()
 	if !silent {
 		pb := spinner.New(spinner.CharSets[11], 100*time.Millisecond, spinner.WithWriterFile(os.Stderr))
 		pb.Prefix = "Downloading...  "
@@ -481,6 +522,7 @@ func (s *Server) Upload(noPrealloc, silent, useBytes, useMebi bool, requests int
 	}
 
 	counter.Start()
+	defer streamProgress("upload", counter, duration)()
 	if !silent {
 		pb := spinner.New(spinner.CharSets[11], 100*time.Millisecond, spinner.WithWriterFile(os.Stderr))
 		pb.Prefix = "Uploading...  "

--- a/main.go
+++ b/main.go
@@ -98,6 +98,15 @@ func main() {
 					"\taffected by --bytes",
 			},
 			&cli.BoolFlag{
+				Name: defs.OptionJSONStream,
+				Usage: "Suppress verbose output, emit newline-delimited JSON\n" +
+					"\tevents on stdout while the test runs: a phase event\n" +
+					"\tas each stage starts, a progress event a second with\n" +
+					"\tthe rate so far, and a final result event with the\n" +
+					"\tsame reports --json prints. Speeds listed in Mbps\n" +
+					"\tand not affected by --bytes",
+			},
+			&cli.BoolFlag{
 				Name:  defs.OptionList,
 				Usage: "Display a list of LibreSpeed.org servers",
 			},

--- a/output/stream.go
+++ b/output/stream.go
@@ -1,0 +1,67 @@
+package output
+
+import (
+	"encoding/json"
+	"sync"
+)
+
+// --- WriteEvent: NDJSON event stream on stdout (--json-stream) ---
+//
+// One JSON object per line: a phase event as each stage starts, a progress
+// event a second while a transfer runs, and a final result event carrying
+// the same reports --json prints. The stream shares stdout with nothing --
+// stream mode implies quiet, and everything human-readable is on stderr.
+
+var (
+	streamMu sync.Mutex // one event per line, even with a ticker goroutine writing
+	stream   bool
+)
+
+// SetStream enables the NDJSON event stream. Called when --json-stream is set.
+func SetStream(v bool) { stream = v }
+
+// StreamEnabled reports whether the NDJSON event stream is enabled.
+func StreamEnabled() bool { return stream }
+
+// PhaseEvent announces that a test stage is starting.
+type PhaseEvent struct {
+	Event string `json:"event"`
+	Phase string `json:"phase"`
+}
+
+// ProgressEvent reports the rate measured so far in the current stage.
+// Progress is percent of the stage's configured duration that has elapsed:
+// a speed test is bounded by time, not by volume, so the byte count -- the
+// thing being measured -- cannot say how much is left, but elapsed over
+// duration can.
+type ProgressEvent struct {
+	Event    string  `json:"event"`
+	Phase    string  `json:"phase"`
+	Seconds  float64 `json:"seconds"`
+	Mbps     float64 `json:"mbps"`
+	Progress int     `json:"progress"`
+}
+
+// ResultEvent terminates the stream with the reports the run produced.
+type ResultEvent struct {
+	Event   string      `json:"event"`
+	Reports interface{} `json:"reports"`
+}
+
+// WriteEvent writes one event as a single NDJSON line to stdout.
+// No-op unless the stream is enabled.
+func WriteEvent(v interface{}) {
+	if !stream {
+		return
+	}
+
+	b, err := json.Marshal(v)
+	if err != nil {
+		WriteError("Error generating stream event: %s\n", err)
+		return
+	}
+
+	streamMu.Lock()
+	defer streamMu.Unlock()
+	Default.out.Write(append(b, '\n'))
+}

--- a/speedtest/helper.go
+++ b/speedtest/helper.go
@@ -79,6 +79,7 @@ output.WriteDebug("IP info: %s\n", output.Sanitize(ispInfo.ProcessedString))
 			// nothing at all until they finish. Report each phase under --debug
 			// instead, with the timings and counts the spinner cannot carry.
 			output.WriteDebug("Ping test starting: %d pings, ICMP: %t\n", pingCount, !noICMP)
+			output.WriteEvent(output.PhaseEvent{Event: "phase", Phase: "ping"})
 			pingStart := time.Now()
 
 			p, jitter, err := currentServer.ICMPPingAndJitter(pingCount, c.String(defs.OptionSource), network)
@@ -105,6 +106,7 @@ output.WriteDebug("IP info: %s\n", output.Sanitize(ispInfo.ProcessedString))
 				output.WriteDebug("Download test skipped\n")
 			} else {
 				output.WriteDebug("Download test starting: %d stream(s), %d chunk(s), up to %ds\n", c.Int(defs.OptionConcurrent), c.Int(defs.OptionChunks), c.Int(defs.OptionDuration))
+				output.WriteEvent(output.PhaseEvent{Event: "phase", Phase: "download"})
 				downloadStart := time.Now()
 
 				download, br, err := currentServer.Download(silent, c.Bool(defs.OptionBytes), c.Bool(defs.OptionMebiBytes), c.Int(defs.OptionConcurrent), c.Int(defs.OptionChunks), time.Duration(c.Int(defs.OptionDuration))*time.Second)
@@ -126,6 +128,7 @@ output.WriteDebug("IP info: %s\n", output.Sanitize(ispInfo.ProcessedString))
 				output.WriteDebug("Upload test skipped\n")
 			} else {
 				output.WriteDebug("Upload test starting: %d stream(s), %d KiB per request, up to %ds\n", c.Int(defs.OptionConcurrent), c.Int(defs.OptionUploadSize), c.Int(defs.OptionDuration))
+				output.WriteEvent(output.PhaseEvent{Event: "phase", Phase: "upload"})
 				uploadStart := time.Now()
 
 				upload, bw, err := currentServer.Upload(c.Bool(defs.OptionNoPreAllocate), silent, c.Bool(defs.OptionBytes), c.Bool(defs.OptionMebiBytes), c.Int(defs.OptionConcurrent), c.Int(defs.OptionUploadSize), time.Duration(c.Int(defs.OptionDuration))*time.Second)
@@ -187,8 +190,9 @@ output.WriteDebug("IP info: %s\n", output.Sanitize(ispInfo.ProcessedString))
 				rep.IP = ispInfo.RawISPInfo.IP
 
 				reps_csv = append(reps_csv, rep)
-			} else if c.Bool(defs.OptionJSON) {
-				// print json if --json is given
+			} else if c.Bool(defs.OptionJSON) || c.Bool(defs.OptionJSONStream) {
+				// the stream's final result event carries the same reports
+				// --json prints, so one parser handles both formats
 				var rep report.JSONReport
 				rep.Timestamp = time.Now()
 
@@ -233,6 +237,8 @@ output.WriteDebug("IP info: %s\n", output.Sanitize(ispInfo.ProcessedString))
 			os.Stdout.Write(b[:])
 			os.Stdout.WriteString("\n")
 		}
+	} else if c.Bool(defs.OptionJSONStream) {
+		output.WriteEvent(output.ResultEvent{Event: "result", Reports: reps_json})
 	}
 
 	return nil

--- a/speedtest/speedtest.go
+++ b/speedtest/speedtest.go
@@ -51,10 +51,22 @@ type PingResult struct {
 func SpeedTest(c *cli.Context) error {
 	// check for suppressed output flags
 	var silent bool
-	if c.Bool(defs.OptionSimple) || c.Bool(defs.OptionJSON) || c.Bool(defs.OptionCSV) {
+	if c.Bool(defs.OptionSimple) || c.Bool(defs.OptionJSON) || c.Bool(defs.OptionCSV) || c.Bool(defs.OptionJSONStream) {
 		output.SetQuiet(true)
 		silent = true
 	}
+
+	// mixing a JSON document into a line stream would leave neither format
+	// parseable on its own, so the stream conflicts with --json and --csv
+	// rather than combining with them
+	if c.Bool(defs.OptionJSONStream) && (c.Bool(defs.OptionJSON) || c.Bool(defs.OptionCSV)) {
+		other := defs.OptionCSV
+		if c.Bool(defs.OptionJSON) {
+			other = defs.OptionJSON
+		}
+		return fmt.Errorf("incompatible options '%s' and '%s'", defs.OptionJSONStream, other)
+	}
+	output.SetStream(c.Bool(defs.OptionJSONStream))
 
 	// check for debug flag
 	if c.Bool(defs.OptionDebug) {


### PR DESCRIPTION
Adds `--json-stream` to emit measurement progress as NDJSON on stdout: phase starts, periodic progress with the current rate and elapsed time, and a final result containing the same reports as `--json`.

```
{"event":"phase","phase":"download"}
{"event":"progress","phase":"download","seconds":4,"mbps":431.2,"progress":27}
{"event":"result","reports":[...]}
```

Progress is based on elapsed time rather than transferred bytes, since the test is duration-bound and the amount of data is the measurement. Conflicts with `--json` and `--csv` to keep each output format independently parseable.