### PR TITLE
fix: recover the client IP address and organisation from current backends

### DIFF
--- a/defs/defs.go
+++ b/defs/defs.go
@@ -2,7 +2,9 @@ package defs
 
 import (
 	"encoding/json"
+	"net"
 	"runtime"
+	"strings"
 )
 
 var (
@@ -39,13 +41,20 @@ type IPInfoResponse struct {
 	Readme       string `json:"readme,omitempty"`
 }
 
-// IP returns the client address from the raw ISP response. The backend may
-// return rawIspInfo as an object, an empty string, or not at all; anything
-// that does not parse as an object yields an empty address.
+// IP returns the client IP address, preferring rawIspInfo and falling
+// back to the first token of processedString when it is a valid IP.
 func (g *GetIPResult) IP() string {
 	var info IPInfoResponse
 	if len(g.RawISPInfo) > 0 {
 		json.Unmarshal(g.RawISPInfo, &info)
 	}
-	return info.IP
+	if info.IP != "" {
+		return info.IP
+	}
+
+	fields := strings.Fields(g.ProcessedString)
+	if len(fields) > 0 && net.ParseIP(fields[0]) != nil {
+		return fields[0]
+	}
+	return ""
 }

--- a/defs/defs_test.go
+++ b/defs/defs_test.go
@@ -1,0 +1,41 @@
+package defs
+
+import "testing"
+
+// The address falls back to processedString whenever rawIspInfo carries none:
+// live backends answer with an empty string, a JSON null, or -- with the
+// current ipinfo schema -- an object that has no ip field at all.
+func TestIPRecoveredFromProcessedString(t *testing.T) {
+	cases := []struct {
+		name      string
+		processed string
+		raw       string
+		want      string
+	}{
+		{"bare IPv6, ISP detection off", "2a00:1028:8388:a84e:8cda:7223:57f8:67a6", `""`, "2a00:1028:8388:a84e:8cda:7223:57f8:67a6"},
+		{"IPv4 with ISP suffix", "192.0.2.1 - Example ISP, CZ", `""`, "192.0.2.1"},
+		{"tab-separated ISP suffix", "192.0.2.1\t- Example ISP", `""`, "192.0.2.1"},
+		{"not an address", "no address here", `""`, ""},
+		{"empty processedString", "", `""`, ""},
+		{"raw is JSON null", "192.0.2.1 - Example ISP", `null`, "192.0.2.1"},
+		{"raw ISP info without IP", "192.0.2.1 - Example ISP", `{"as_name":"Example ISP","asn":"AS123"}`, "192.0.2.1"},
+	}
+
+	for _, c := range cases {
+		g := GetIPResult{ProcessedString: c.processed, RawISPInfo: []byte(c.raw)}
+		if got := g.IP(); got != c.want {
+			t.Errorf("%s: IP() = %q, want %q", c.name, got, c.want)
+		}
+	}
+}
+
+// The raw field is the backend's own answer; the token is only a stand-in.
+func TestIPPrefersRawOverProcessedString(t *testing.T) {
+	g := GetIPResult{
+		ProcessedString: "198.51.100.7 - X",
+		RawISPInfo:      []byte(`{"ip":"192.0.2.1"}`),
+	}
+	if got := g.IP(); got != "192.0.2.1" {
+		t.Errorf("IP() = %q, want %q", got, "192.0.2.1")
+	}
+}

--- a/defs/server_test.go
+++ b/defs/server_test.go
@@ -52,8 +52,9 @@ func TestGetIPInfoKeepsEmptyRawIspInfo(t *testing.T) {
 	if got.ProcessedString != "10.0.0.70" {
 		t.Errorf("ProcessedString = %q, want %q", got.ProcessedString, "10.0.0.70")
 	}
-	if got.IP() != "" {
-		t.Errorf("IP() = %q, want empty", got.IP())
+	// With rawIspInfo empty the address is recovered from processedString.
+	if got.IP() != "10.0.0.70" {
+		t.Errorf("IP() = %q, want %q", got.IP(), "10.0.0.70")
 	}
 
 	b, err := json.Marshal(got)
@@ -82,8 +83,9 @@ func TestGetIPInfoAbsentRawIspInfo(t *testing.T) {
 	if got.ProcessedString != "1.2.3.4" {
 		t.Errorf("ProcessedString = %q, want %q", got.ProcessedString, "1.2.3.4")
 	}
-	if got.IP() != "" {
-		t.Errorf("IP() = %q, want empty", got.IP())
+	// Recovered from processedString when rawIspInfo is absent entirely.
+	if got.IP() != "1.2.3.4" {
+		t.Errorf("IP() = %q, want %q", got.IP(), "1.2.3.4")
 	}
 }
 

--- a/report/json.go
+++ b/report/json.go
@@ -36,9 +36,21 @@ type Client struct {
 // The payload may be an object, an empty string, or absent; anything that does
 // not parse as an object yields an empty Client rather than an error.
 func NewClient(raw json.RawMessage) Client {
-	var c Client
-	if len(raw) > 0 {
-		json.Unmarshal(raw, &c.IPInfoResponse)
+	var data struct {
+		defs.IPInfoResponse
+		ASName string `json:"as_name"`
 	}
+
+	if len(raw) > 0 {
+		json.Unmarshal(raw, &data)
+	}
+
+	c := Client{IPInfoResponse: data.IPInfoResponse}
+
+	// Current backends use as_name, while older ones use org.
+	if c.Organization == "" {
+		c.Organization = data.ASName
+	}
+
 	return c
 }

--- a/report/json_test.go
+++ b/report/json_test.go
@@ -1,0 +1,44 @@
+package report
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestNewClientOrganisation(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{"old schema", `{"ip":"192.0.2.1","org":"AS64496 Example"}`, "AS64496 Example"},
+		{"current ipinfo schema", `{"as_name":"O2 Czech Republic, a.s.","asn":"AS5610"}`, "O2 Czech Republic, a.s."},
+		{"org takes precedence over as_name", `{"org":"Old Name","as_name":"New Name"}`, "Old Name"},
+		{"neither", `{"ip":"192.0.2.1"}`, ""},
+		{"empty string payload", `""`, ""},
+	}
+
+	for _, c := range cases {
+		got := NewClient([]byte(c.raw)).Organization
+		if got != c.want {
+			t.Errorf("%s: Organization = %q, want %q", c.name, got, c.want)
+		}
+	}
+}
+
+// as_name is an input alias for org, not a report field: accepting it must
+// not start emitting it.
+func TestClientJSONDoesNotLeakASName(t *testing.T) {
+	c := NewClient([]byte(`{"as_name":"O2 Czech Republic, a.s."}`))
+	b, err := json.Marshal(c)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if strings.Contains(string(b), "as_name") {
+		t.Errorf("client JSON leaks as_name: %s", b)
+	}
+	if !strings.Contains(string(b), `"org":"O2 Czech Republic, a.s."`) {
+		t.Errorf("org not filled from as_name: %s", b)
+	}
+}

--- a/speedtest/helper.go
+++ b/speedtest/helper.go
@@ -205,6 +205,9 @@ output.WriteDebug("IP info: %s\n", output.Sanitize(ispInfo.ProcessedString))
 
 				rep.Client = report.NewClient(ispInfo.RawISPInfo)
 				rep.Client.Readme = ""
+				// IP() falls back to processedString, so the report carries an
+				// address even when the backend keeps rawIspInfo empty.
+				rep.Client.IP = ispInfo.IP()
 
 				reps_json = append(reps_json, rep)
 			}


### PR DESCRIPTION
Two related fixes for reports losing client information:

- The client IP address falls back to the leading token of `processedString` when `rawIspInfo` carries none. Live backends answer with `""`, `null`, or — with the current ipinfo schema — an object without an `ip` field, and in all of those cases reports carried no address at all.
- The client organisation falls back to `as_name`, which the current ipinfo schema uses where older backends send `org`. The alias is input-only: reports keep emitting `org` and never `as_name`.

Tested against live backends with all three `rawIspInfo` shapes (empty string, null, object without `ip`).