### PR TITLE
fix: start the progress clock with the test window

### DIFF
--- a/defs/server.go
+++ b/defs/server.go
@@ -391,7 +391,6 @@ func (s *Server) Download(silent bool, useBytes, useMebi bool, requests int, chu
 	}
 
 	counter.Start()
-	defer streamProgress("download", counter, duration)()
 	if !silent {
 		pb := spinner.New(spinner.CharSets[11], 100*time.Millisecond, spinner.WithWriterFile(os.Stderr))
 		pb.Prefix = "Downloading...  "
@@ -421,6 +420,11 @@ func (s *Server) Download(silent bool, useBytes, useMebi bool, requests int, chu
 		spawnDownload()
 		time.Sleep(200 * time.Millisecond)
 	}
+
+	// One clock for the whole test window: the ticker and the timeout both
+	// start here, after ramp-up, so reported progress cannot run ahead of the
+	// test it describes.
+	defer streamProgress("download", counter, duration)()
 	timeout := time.After(duration)
 Loop:
 	for {
@@ -536,7 +540,6 @@ func (s *Server) Upload(noPrealloc, silent, useBytes, useMebi bool, requests int
 	}
 
 	counter.Start()
-	defer streamProgress("upload", counter, duration)()
 	if !silent {
 		pb := spinner.New(spinner.CharSets[11], 100*time.Millisecond, spinner.WithWriterFile(os.Stderr))
 		pb.Prefix = "Uploading...  "
@@ -566,6 +569,11 @@ func (s *Server) Upload(noPrealloc, silent, useBytes, useMebi bool, requests int
 		spawnUpload()
 		time.Sleep(200 * time.Millisecond)
 	}
+
+	// One clock for the whole test window: the ticker and the timeout both
+	// start here, after ramp-up, so reported progress cannot run ahead of the
+	// test it describes.
+	defer streamProgress("upload", counter, duration)()
 	timeout := time.After(duration)
 Loop:
 	for {


### PR DESCRIPTION
The progress ticker started before the transfer ramp-up while the duration timeout started after it, so `progress` ran ahead of the test by the ramp-up time — with the default three streams it reached 100 six tenths of a second before the phase ended.

Measured against a live server with `--duration 5 --concurrent 3`:

| | download phase | `progress: 100` arrived |
|---|---|---|
| before | 5.6 s | 0.6 s before the phase ended |
| after | 5.6 s | at the end of the phase |

Introduced by #145 and found while porting `--json-stream` to the Rust client, where the same flaw was carried over and fixed.